### PR TITLE
Add Sankey diagram view

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="css/style.css">
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-sankey@0.9.1/dist/chartjs-chart-sankey.min.js"></script>
 </head>
 <body>
     <header class="container">
@@ -39,6 +40,7 @@
                      <option value="subsector" selected>Subsector Details</option>
                      <option value="balance">Overall Balance</option>
                      <option value="supply">Supply & Transformations</option>
+                     <option value="sankey">Energy Flow Sankey</option>
                  </select>
             </div>
 
@@ -46,6 +48,11 @@
                 <label for="selectSubsector">Subsector:</label>
                 <select id="selectSubsector">
                     </select>
+            </div>
+
+            <div id="sankeyYearSelector" class="hidden">
+                <label for="selectSankeyYear">Year:</label>
+                <select id="selectSankeyYear"></select>
             </div>
 
             <section id="subsectorChartsSection">
@@ -72,6 +79,11 @@
                     <div class="chart-box"><h3>Power Generation</h3><canvas id="powerMixChart"></canvas></div>
                     <div class="chart-box"><h3>Hydrogen Production</h3><canvas id="hydrogenMixChart"></canvas></div>
                     </div>
+            </section>
+
+            <section id="sankeySection" class="hidden">
+                <h3 class="chart-section-heading">Energy Flow</h3>
+                <div class="chart-box"><canvas id="sankeyCanvas"></canvas></div>
             </section>
 
         </main>

--- a/js/main.js
+++ b/js/main.js
@@ -16,7 +16,7 @@ async function initializeApp() {
     try {
         setBtn('Loading...', true);
         // Basic check for function existence (assumes they are global)
-        if (![loadAndStructureData, initializeSidebarInputs, populateSubsectorDropdown, setupEventListeners, getUserInputsAndParams, runModelCalculation, updateCharts].every(f => typeof f === 'function')) {
+        if (![loadAndStructureData, initializeSidebarInputs, populateSubsectorDropdown, populateYearDropdown, setupEventListeners, getUserInputsAndParams, runModelCalculation, updateCharts].every(f => typeof f === 'function')) {
             throw new Error("Core function missing.");
         }
         appState.structuredData = await loadAndStructureData();
@@ -25,6 +25,7 @@ async function initializeApp() {
 
         initializeSidebarInputs(appState.structuredData);
         populateSubsectorDropdown(appState.structuredData);
+        populateYearDropdown(appState.structuredData);
         console.log("UI init.");
 
         setupEventListeners(appState); // Passes state object

--- a/js/modelLogic.js
+++ b/js/modelLogic.js
@@ -163,6 +163,7 @@ function runModelCalculation(structuredData, userParams) {
         });
         resYr.ecPostHydrogen = { ...resYr.fecByFuel }; delete resYr.ecPostHydrogen['Hydrogen'];
         Object.entries(h2Inputs).forEach(([f, dem]) => { if (dem > 1e-3) resYr.ecPostHydrogen[f] = (resYr.ecPostHydrogen[f] || 0) + dem; });
+        resYr.hydrogenInputs = h2Inputs;
 
         // --- 6. Power Transform ---
         const ecElec = resYr.ecPostHydrogen['Electricity'] || 0;
@@ -175,6 +176,7 @@ function runModelCalculation(structuredData, userParams) {
         });
         resYr.ecPostPower = { ...resYr.ecPostHydrogen }; delete resYr.ecPostPower['Electricity'];
         Object.entries(powerInputs).forEach(([f, dem]) => { if (dem > 1e-3) resYr.ecPostPower[f] = (resYr.ecPostPower[f] || 0) + dem; });
+        resYr.powerInputs = powerInputs;
 
         // --- 7. Other Transforms ---
         const otherInputs = {};
@@ -189,9 +191,11 @@ function runModelCalculation(structuredData, userParams) {
                              otherInputs[p_primary] = (otherInputs[p_primary] || 0) + demandConvert * mixFrac * (uCons || 0);
                          }
                      });
-                 });
+                });
              }
         });
+
+        resYr.otherInputs = otherInputs;
 
         // --- 8. PED ---
         resYr.pedByFuel = { ...otherInputs };

--- a/js/uiController.js
+++ b/js/uiController.js
@@ -105,6 +105,15 @@ function populateSubsectorDropdown(structuredData) {
     console.log("Subsector dropdown populated.");
 }
 
+function populateYearDropdown(structuredData) {
+    const sel = document.getElementById('selectSankeyYear'); if (!sel) return;
+    sel.innerHTML = '';
+    const { years = [] } = structuredData ?? {};
+    years.forEach(y => sel.add(new Option(String(y), String(y))));
+    if (sel.options.length > 0) sel.value = sel.options[0].value;
+    console.log('Year dropdown populated.');
+}
+
 // --- Input Gathering (Concise) ---
 function getUserInputsAndParams(structuredData) {
     const { sectors = [], subsectors = {}, technologies = {}, powerTechs = [], hydrogenTechs = [], allEndUseSubsectors = [], startYear, endYear } = structuredData ?? {};
@@ -137,12 +146,13 @@ function getUserInputsAndParams(structuredData) {
 function handleChartViewChange() {
     const view = document.getElementById('selectChartView')?.value ?? 'subsector';
     document.getElementById('subsectorSelector')?.classList.toggle('hidden', view !== 'subsector');
-    ['subsectorChartsSection', 'balanceChartsSection', 'supplyChartsSection'].forEach(id => {
+    document.getElementById('sankeyYearSelector')?.classList.toggle('hidden', view !== 'sankey');
+    ['subsectorChartsSection', 'balanceChartsSection', 'supplyChartsSection', 'sankeySection'].forEach(id => {
         document.getElementById(id)?.classList.toggle('hidden', !id.toLowerCase().includes(view));
     });
 }
 function setupEventListeners(appState) {
-    const btn = document.getElementById('runModelBtn'), subSel = document.getElementById('selectSubsector'), viewSel = document.getElementById('selectChartView');
+    const btn = document.getElementById('runModelBtn'), subSel = document.getElementById('selectSubsector'), viewSel = document.getElementById('selectChartView'), yearSel = document.getElementById('selectSankeyYear');
     if (!btn || !subSel || !viewSel || !appState.structuredData) return console.error("Missing elements/data for listeners.");
     btn.onclick = async () => {
         btn.disabled = true; btn.textContent = 'Calculating...';
@@ -162,6 +172,7 @@ function setupEventListeners(appState) {
         }
     };
     viewSel.onchange = handleChartViewChange;
+    if (yearSel) yearSel.onchange = () => { if (typeof updateCharts === 'function' && appState.latestResults) updateCharts(appState.latestResults, appState.structuredData); };
     handleChartViewChange(); // Initial call
     console.log("UI Listeners set up.");
 }


### PR DESCRIPTION
## Summary
- load chartjs-chart-sankey plugin and add sankey section in HTML
- allow selecting the year for the sankey view
- store transformation inputs when running the model
- generate sankey flows from model results
- update UI controller and main init to support the new dropdown

## Testing
- `node -e "require('./js/charting.js')"`
- `node -e "require('./js/uiController.js')"`
- `node -e "require('./js/main.js')" (fails: document is not defined)`