### PR TITLE
Revert Sankey changes and add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ This project implements an energy model based on the S-curve methodology describ
     * `/lib`: (Optional) For third-party libraries like PapaParse or Chart.js
 * `/data`: Contains input data CSV files (structure based on `SEM dataset - *.csv` files)
 
+## Setup
+
+Run the setup script once to install dependencies locally and copy required libraries into `js/lib`:
+
+```bash
+bash scripts/setup.sh
+```
+
+This only needs to be done before running tests or serving the project for the first time.
+
 ## Methodology
 
 The core calculations follow the logic outlined in the `Methodology.docx` document[cite: 1], including:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Initialize npm project if package.json doesn't exist
+if [ ! -f package.json ]; then
+  npm init -y >/dev/null
+fi
+
+npm install chart.js@4.4.1 chartjs-chart-sankey@0.9.1 papaparse http-server >/dev/null
+
+# Copy required JS files to js/lib
+mkdir -p js/lib
+cp node_modules/chart.js/dist/chart.umd.js js/lib/
+cp node_modules/chartjs-chart-sankey/dist/chartjs-chart-sankey.min.js js/lib/
+cp node_modules/papaparse/papaparse.min.js js/lib/
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- remove the Sankey diagram view introduced in the previous commit
- provide a setup script to install Chart.js and other dependencies
- document running the script in a new README Setup section

## Testing
- `node -e "require('./js/charting.js')"`
- `node -e "require('./js/uiController.js')"`
- `node -e "require('./js/main.js')"` *(fails: document is not defined)*
