### PR TITLE
Update PED aggregation for overall balance

### DIFF
--- a/js/charting.js
+++ b/js/charting.js
@@ -63,7 +63,7 @@ function updateCharts(results, config) {
 
     // --- Balance Charts ---
     createOrUpdateChart('fecFuelChart', 'bar', { labels: years, datasets: createDatasets(endUseFuels, (fuel, i) => ({ label: fuel, data: years.map(y => (results?.[y]?.fecByFuel?.[fuel] ?? 0) / GJ_PER_EJ), backgroundColor: getTechColor(fuel, i) })) }, stackedBarOpts('Total FEC (EJ)'));
-    createOrUpdateChart('pedFuelChart', 'bar', { labels: years, datasets: createDatasets(primaryFuels, (fuel, i) => ({ label: fuel, data: years.map(y => (results?.[y]?.pedByFuel?.[fuel] ?? 0) / GJ_PER_EJ), backgroundColor: getTechColor(fuel, i) })) }, stackedBarOpts('Total PED (EJ)'));
+    createOrUpdateChart('pedFuelChart', 'bar', { labels: years, datasets: createDatasets(primaryFuels, (fuel, i) => ({ label: fuel, data: years.map(y => (results?.[y]?.pedEndUseByFuel?.[fuel] ?? results?.[y]?.pedByFuel?.[fuel] ?? 0) / GJ_PER_EJ), backgroundColor: getTechColor(fuel, i) })) }, stackedBarOpts('Total PED (EJ)'));
     createOrUpdateChart('ueFuelChart', 'bar', { labels: years, datasets: createDatasets(endUseFuels, (fuel, i) => ({ label: fuel, data: years.map(y => (results?.[y]?.ueByFuel?.[fuel] ?? 0) / GJ_PER_EJ), backgroundColor: getTechColor(fuel, i) })) }, stackedBarOpts('Total Useful Energy (EJ)'));
 
     // --- Supply Charts ---


### PR DESCRIPTION
## Summary
- compute final-sector PED separately from total PED
- expose PED by end-use sector in results
- use `pedEndUseByFuel` for the PED chart so overall balance excludes power and energy industry sectors

## Testing
- `node - <<'NODE' ...`